### PR TITLE
Upgrade to usabilitydynamics/udx-worker:0.12.0 [UAT-78]

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use the UDX worker as the base image
-FROM usabilitydynamics/udx-worker:0.11.0
+FROM usabilitydynamics/udx-worker:0.12.0
 
 # Add metadata labels
 LABEL maintainer="UDX"
@@ -7,8 +7,8 @@ LABEL version="0.8.0"
 
 # Arguments and Environment Variables
 ARG PHP_VERSION=8.3
-ARG PHP_PACKAGE_VERSION=8.3.6-0ubuntu0.24.04.3
-ARG NGINX_VERSION=1.24.0-2ubuntu7.1
+ARG PHP_PACKAGE_VERSION=8.3.11-0ubuntu4
+ARG NGINX_VERSION=1.26.0-3ubuntu1
 
 # Set the PHP_VERSION as an environment variable
 ENV PHP_VERSION="${PHP_VERSION}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM usabilitydynamics/udx-worker:0.12.0
 
 # Add metadata labels
 LABEL maintainer="UDX"
-LABEL version="0.8.0"
+LABEL version="0.9.0"
 
 # Arguments and Environment Variables
 ARG PHP_VERSION=8.3


### PR DESCRIPTION
Upgrade to `udx-worker:0.12.0` includes:

- Migrate to `ubuntu:25.04`
- Fixes vulnerability (`high/medium/low`)