### PR TITLE
Fix GPG Verification [UAT-83]

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 # Use the UDX worker as the base image
-FROM usabilitydynamics/udx-worker:0.16.0
+FROM usabilitydynamics/udx-worker:0.17.0
 
 # Add metadata labels
 LABEL maintainer="UDX"
-LABEL version="0.12.0"
+LABEL version="0.13.0"
 
 # Arguments and Environment Variables
 ARG PHP_VERSION=8.4
@@ -27,7 +27,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     php"${PHP_VERSION}"-curl="${PHP_PACKAGE_VERSION}" \
     php"${PHP_VERSION}"-xml="${PHP_PACKAGE_VERSION}" \
     php"${PHP_VERSION}"-zip="${PHP_PACKAGE_VERSION}" && \
-    apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
+    apt-get clean && \
+    rm -rf /tmp/* /var/tmp/* && \
+    mkdir -p /etc/apt/sources.list.d && \
+    chmod 755 /etc/apt/sources.list.d && \
     mkdir -p /var/log/php /var/log/nginx /run/php /tmp /var/lib/nginx/body && \
     touch /var/log/php/fpm.log && \
     chown -R "${USER}:${USER}" /var/log/php /var/log/nginx /run/php /tmp /var/lib/nginx $APP_HOME && \

--- a/README.md
+++ b/README.md
@@ -150,5 +150,5 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 
 ---
 <div align="center">
-Built with ❤️ by <a href="https://udx.io">UDX</a>
+Built by <a href="https://udx.io">UDX</a> © 2025
 </div>


### PR DESCRIPTION
## Changes

- Upgrade to `usabilitydynamics/udx-worker:0.17.0`
- Added `/etc/apt/sources.list.d` setup with proper permissions

## Impact
- Fixed GPG verification in child images
- Child images can now add repositories without GPG errors

## Note
Same directory setup needed in child images for GPG verification to work