### PR TITLE
Added PHP_PACKAGE_VERSION env

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,15 +3,16 @@ FROM usabilitydynamics/udx-worker:0.18.0
 
 # Add metadata labels
 LABEL maintainer="UDX"
-LABEL version="0.15.0"
+LABEL version="0.16.0"
 
 # Arguments and Environment Variables
 ARG PHP_VERSION=8.4
 ARG PHP_PACKAGE_VERSION=8.4.5-1ubuntu1	
 ARG NGINX_VERSION=1.26.3-2ubuntu1
 
-# Set the PHP_VERSION as an environment variable
+# Set the PHP_VERSION and PHP_PACKAGE_VERSION as environment variables
 ENV PHP_VERSION="${PHP_VERSION}"
+ENV PHP_PACKAGE_VERSION="${PHP_PACKAGE_VERSION}"
 # Standard directories for PHP application
 ENV APP_HOME="/var/www"
 


### PR DESCRIPTION
Successful build: https://github.com/udx/worker-php/actions/runs/14571987863

## Changes

Added `PHP_PACKAGE_VERSION` env support so it can be re-used in child images for installing php sub modules. 

Example:

```
apt-get install -y php"${PHP_VERSION}"-dev="${PHP_PACKAGE_VERSION}" 
```