### PR TITLE
updated base Docker Image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 # Use the UDX worker as the base image
-FROM usabilitydynamics/udx-worker:0.23.0
+FROM usabilitydynamics/udx-worker:0.24.0
 
 # Add metadata labels
 LABEL maintainer="UDX"
-LABEL version="0.22.0"
+LABEL version="0.23.0"
 
 # Arguments and Environment Variables
 ARG PHP_VERSION=8.4


### PR DESCRIPTION
- updated base Docker Image to the latest version `0.24.0`
- addressed high severity vulnerability in the `aws cli` package