### PR TITLE
fix: preserve apt temporary directory permissions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     mkdir -p /var/log/php /var/log/nginx /run/php /var/lib/nginx/body && \
     touch /var/log/php/fpm.log && \
     chown -R "${USER}:${USER}" /var/log/php /var/log/nginx /run/php /var/lib/nginx $APP_HOME && \
-    chmod -R 755 /var/log/php /var/log/nginx /run/php /var/lib/nginx $APP_HOME
+    chmod 755 /var/log/php /var/log/nginx /run/php /var/lib/nginx /var/lib/nginx/body $APP_HOME
 
 # Copy NGINX and PHP configurations
 COPY etc/configs/nginx/nginx.conf /etc/nginx/nginx.conf

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use the UDX worker as the base image
-FROM usabilitydynamics/udx-worker:0.45.0
+FROM usabilitydynamics/udx-worker:0.47.0
 
 # Add metadata labels
 LABEL maintainer="UDX"

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ ENV APP_HOME="/var/www"
 USER root
 
 # Install dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-get update -o APT::Update::Error-Mode=any && apt-get install -y --no-install-recommends \
     nginx="${NGINX_VERSION}" \
     php"${PHP_VERSION}"-fpm="${PHP_PACKAGE_VERSION}" \
     php"${PHP_VERSION}"-cli="${PHP_PACKAGE_VERSION}" \
@@ -32,10 +32,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     rm -rf /tmp/* /var/tmp/* && \
     mkdir -p /etc/apt/sources.list.d && \
     chmod 755 /etc/apt/sources.list.d && \
-    mkdir -p /var/log/php /var/log/nginx /run/php /tmp /var/lib/nginx/body && \
+    mkdir -p /var/log/php /var/log/nginx /run/php /var/lib/nginx/body && \
     touch /var/log/php/fpm.log && \
-    chown -R "${USER}:${USER}" /var/log/php /var/log/nginx /run/php /tmp /var/lib/nginx $APP_HOME && \
-    chmod -R 755 /var/log/php /var/log/nginx /run/php /tmp /var/lib/nginx $APP_HOME
+    chown -R "${USER}:${USER}" /var/log/php /var/log/nginx /run/php /var/lib/nginx $APP_HOME && \
+    chmod -R 755 /var/log/php /var/log/nginx /run/php /var/lib/nginx $APP_HOME
 
 # Copy NGINX and PHP configurations
 COPY etc/configs/nginx/nginx.conf /etc/nginx/nginx.conf

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ ENV APP_HOME="/var/www"
 USER root
 
 # Install dependencies
-RUN apt-get update -o APT::Update::Error-Mode=any && apt-get install -y --no-install-recommends \
+RUN apt-get update && apt-get install -y --no-install-recommends \
     nginx="${NGINX_VERSION}" \
     php"${PHP_VERSION}"-fpm="${PHP_PACKAGE_VERSION}" \
     php"${PHP_VERSION}"-cli="${PHP_PACKAGE_VERSION}" \


### PR DESCRIPTION
## Summary
- Preserve /tmp as the standard root-owned sticky directory so apt can verify repository signatures.
- Avoid recursively changing permissions on application and log files.
- Upgrade the worker base image from 0.45.0 to 0.47.0.

## Validation
- Rebuilt worker-php locally and verified a signed apt refresh and expected runtime directory modes.
- Rebuilt worker-site against the local parent; the full image build succeeded with current Ubuntu dependencies.